### PR TITLE
Fix the Self Agent Entity Bug

### DIFF
--- a/minecraft_bot/src/action_schemas.py
+++ b/minecraft_bot/src/action_schemas.py
@@ -103,17 +103,18 @@ def move_toward_block(block_atom):
     map_handle = (atomspace.get_atoms_by_name(
         types.SpaceMapNode, "MCmap")[0]).h
     cur_map = space_server.get_map(map_handle)
+    cur_er = space_server.get_entity_recorder(map_handle)
     block_pos = cur_map.get_block_location(block_atom.h)
     if block_pos == None:
         print 'block postion not found.',block_atom
         return TruthValue(0,1)
-    dest = get_near_free_point(cur_map, block_pos, 2, (1,0,0), True)
+    dest = get_near_free_point(atomspace, cur_map, block_pos, 2, (1,0,0), True)
 
     if dest == None:
         print 'get_no_free_point'
     print 'block_pos, dest', block_pos, dest
-    self_handle = cur_map.get_self_agent_entity()
-    self_pos = cur_map.get_last_appeared_location(self_handle)
+    self_handle = cur_er.get_self_agent_entity()
+    self_pos = cur_er.get_last_appeared_location(self_handle)
 
     if (math.floor(self_pos[0]) == dest[0]
         and math.floor(self_pos[1]) == dest[1]


### PR DESCRIPTION
Because in the newest Spatial code we save the self agent entity in EntityRecorder, now we fix this in the action schema to make the functionality of finding block work.

Warning: since I haven't pull the patch of spatial.pyx/pxd spacetime.pyx in opencog/opencog repo (I'm not sure which branch to send PR). You have to change code by hand in your opencog codebase. Here's the diff https://gist.github.com/chenesan/e846a6452f0820ac9b6b:
